### PR TITLE
Removed extra characters

### DIFF
--- a/profileTemplate
+++ b/profileTemplate
@@ -169,5 +169,4 @@ sub  get_DTI_Site_CandID_Visit {
     }else{
         return  undef;
     }
-                                                              194,6         98%
 }


### PR DESCRIPTION
The extra characters at the end of the profiletemplate (causing the template not to work) are now removed.
