### PR TITLE
Deprecated defined on array and hashes

### DIFF
--- a/addScannerFields.pl
+++ b/addScannerFields.pl
@@ -52,7 +52,7 @@ unless(scalar(@leftovers) == 0) {
 if(-f "$ENV{LORIS_CONFIG}/.loris_mri/$profile") {
 	{ package Settings; do "$ENV{LORIS_CONFIG}/.loris_mri/$profile" }
 }
-if ($profile && !defined @Settings::db) {
+if ($profile && !@Settings::db) {
     print "\n\tERROR: You don't have a configuration file named '$profile' in:  $ENV{LORIS_CONFIG}/.loris_mri/ \n\n"; exit 33;
 } 
 if(!$profile) { print $Usage; print "\n\tERROR: You must specify an existing profile.\n\n";  exit 33;  }

--- a/addSeriesAndFileRecords.pl
+++ b/addSeriesAndFileRecords.pl
@@ -57,7 +57,7 @@ if ($version) { print "$versionInfo\n"; exit; }
 
 # checking for profile settings
 if($profile && -f "$ENV{LORIS_CONFIG}/.loris_mri/$profile") { { package Settings; do "$ENV{LORIS_CONFIG}/.loris_mri/$profile" } }    
-if ($profile && !defined @Settings::db) { print "\n\tERROR: You don't have a configuration file named '$profile' in:  $ENV{LORIS_CONFIG}/.loris_mri/ \n\n"; exit 33; }
+if ($profile && !@Settings::db) { print "\n\tERROR: You don't have a configuration file named '$profile' in:  $ENV{LORIS_CONFIG}/.loris_mri/ \n\n"; exit 33; }
 
 
 # basic error checking on tarchive

--- a/dicomSummary.pl
+++ b/dicomSummary.pl
@@ -81,7 +81,7 @@ if ($version) { print "$versionInfo\n"; exit; }
 
 # checking for profile settings
 if($profile && -f "$ENV{LORIS_CONFIG}/.loris_mri/$profile") { { package Settings; do "$ENV{LORIS_CONFIG}/.loris_mri/$profile" } }    
-if ($profile && !defined @Settings::db) { print "\n\tERROR: You don't have a configuration file named '$profile' in:  $ENV{LORIS_CONFIG}/.loris_mri/ \n\n"; exit 33; }
+if ($profile && !@Settings::db) { print "\n\tERROR: You don't have a configuration file named '$profile' in:  $ENV{LORIS_CONFIG}/.loris_mri/ \n\n"; exit 33; }
 
 
 # basic error checking on dcm dir

--- a/dicomTar.pl
+++ b/dicomTar.pl
@@ -73,7 +73,7 @@ if ($version) { print "Version: $versionInfo\n"; exit; }
 if(-f "$ENV{LORIS_CONFIG}/.loris_mri/$profile") {
 	{ package Settings; do "$ENV{LORIS_CONFIG}/.loris_mri/$profile" }
 }
-if ($profile && !defined @Settings::db) {
+if ($profile && !@Settings::db) {
     print "\n\tERROR: You don't have a configuration file named '$profile' in:  $ENV{LORIS_CONFIG}/.loris_mri/ \n\n"; exit 33;
 } 
 # The source and the target dir have to be present and must be directories. The absolute path will be supplied if necessary

--- a/updateMRI_Upload.pl
+++ b/updateMRI_Upload.pl
@@ -81,7 +81,7 @@ if (-f "$ENV{LORIS_CONFIG}/.loris_mri/$profile") {
     }
 }
 
-if ($profile && !defined @Settings::db) {
+if ($profile && !@Settings::db) {
     print "\n\tERROR: You don't have a configuration file named '$profile' in:
             $ENV{LORIS_CONFIG}/.loris_mri/ \n\n"; 
     exit 2;


### PR DESCRIPTION
Remove following warnings from the console:
defined(@array) is deprecated at ...
	(Maybe you should just omit the defined()?)

Use of defined on aggregates (hashes and arrays) is deprecated. It used to report whether memory for that aggregate had ever been allocated. Should instead use a simple test for size: if (@an_array).