### PR TITLE
Verbose option - in line with pull request 104 in Loris-MRI

### DIFF
--- a/dicomSummary.pl
+++ b/dicomSummary.pl
@@ -159,7 +159,7 @@ foreach $dcmdir (@dcmDirs) {
 	$dbh = &DB::DBI::connect_to_db(@Settings::db);
 	my $update = 1 unless !$dbreplace;
 	$summary->database($dbh, $metaname, $update);
-	print "\nDone\n";
+	print "\nDone dicomSummary.pl execution\n" if $verbose;
 	exit;
     }
 }

--- a/dicomTar.pl
+++ b/dicomTar.pl
@@ -180,7 +180,7 @@ print  $tarinfo if $verbose;
 my $success;
 if ($dbase) {
     $dbh = &DB::DBI::connect_to_db(@Settings::db);
-    print "Adding archive info into database\n" if $verbose;
+    print "\nAdding archive info into database\n" if $verbose;
     my $update          = 1 if $clobber;
     my $ArchiveLocation = $finalTarget;
     $ArchiveLocation    =~ s/$targetlocation\/?//g;
@@ -193,8 +193,8 @@ print "\nRemoving temporary files from target location\n\n" if $verbose;
 
 # now report database failure (was not above to ensure temp files were erased)
 if ($dbase) {
-    if ($success) { print "\nDone\n" if $verbose; }
-    else { print "the database command failed\n"; exit 22; }
+    if ($success) { print "\nDone adding archive info into database\n" if $verbose; }
+    else { print "\nThe database command failed\n"; exit 22; }
 }
 
 # call the updateMRI_upload script###

--- a/dicomTar.pl
+++ b/dicomTar.pl
@@ -25,7 +25,7 @@ my $versionInfo = sprintf "%d", q$Revision: 9 $ =~ /: (\d+)/;
 my $tarTypeVersion = 1;
 # Set stuff for GETOPT
 my ($dcm_source, $targetlocation);
-my $verbose    = 1;
+my $verbose    = 0;
 my $profile    = undef;
 my $neurodbCenterName = undef;
 my $clobber    = 0;

--- a/updateMRI_Upload.pl
+++ b/updateMRI_Upload.pl
@@ -183,5 +183,5 @@ QUERY
 my $mri_upload_insert = $dbh->prepare($query);
 $mri_upload_insert->execute($User,$tarchiveID,$source_location);
 
-print "Done!\n";
+print "Done updateMRI_upload.pl execution!\n" if $verbose;
 exit 0;


### PR DESCRIPTION
A couple of message cleanup and setting $verbose to 0 by default (it gets set now from the command line with '-verbose').
This is a continuation of pull request 104 in Loris-MRI:
https://github.com/aces/Loris-MRI/pull/104
and
https://github.com/aces/Loris/pull/1567