### PR TITLE
site or rather, study, no longer hard coded

### DIFF
--- a/profileTemplate
+++ b/profileTemplate
@@ -169,8 +169,8 @@ sub filterParameters {
 sub  get_DTI_Site_CandID_Visit {
     my ($native_dir) =   @_;
 
-    if  ($native_dir =~  ~ /assembly\/(\d\d\d\d\d\d)\/(V\d{1,2})\/mri\//i)  {   # when only one site
-        my  $site   =   $prefix;                          # when only one site
+    if  ($native_dir =~  /assembly\/(\d\d\d\d\d\d)\/(V\d{1,2})\/mri\//i)  {  
+        my  $site   =   $prefix;                          
         my  $subjID =   $1;
         my  $visit  =   $2;
         return  ($site,$subjID,$visit);

--- a/profileTemplate
+++ b/profileTemplate
@@ -167,10 +167,10 @@ sub filterParameters {
 # ----------- OPTIONAL SUBROUTINE
 # Fetch site, CandID and Visit info from DTI folder.
 sub  get_DTI_Site_CandID_Visit {
-    my ($dir) =   @_;
+    my ($native_dir) =   @_;
 
-    if  ($dir =~  /\/*([0-9]+)\/([N,P][A,R][P,E]EN00)/i)  {   # when only one site
-        my  $site   =   "PreventAD";                                  # when only one site
+    if  ($native_dir =~  ~ /assembly\/(\d\d\d\d\d\d)\/(V\d{1,2})\/mri\//i)  {   # when only one site
+        my  $site   =   $prefix;                          # when only one site
         my  $subjID =   $1;
         my  $visit  =   $2;
         return  ($site,$subjID,$visit);


### PR DESCRIPTION
The site (which is more precisely the study or project) is now taken from the prefix variable. This is how the minc files get named, based on Settings::prefix (in MRIProcessingUtility.pm, registerScanIntoDB()).
The subjID is assumed to be 6 digits, and the Visit is V followed by 1 or 2 digits (V1 or V01 for the first visit)