### PR TITLE
Removed getIncomingDir routine from profileTemplate; it is no longer used

### DIFF
--- a/profileTemplate
+++ b/profileTemplate
@@ -84,11 +84,6 @@ $QCed2_step   =   'INTERLACE_outputDWIFileNameSuffix';
 # -----------------------------------------------------------------------------------------------
 =cut
 
-sub getIncomingDir {
-    my $site = shift;
-    return $tarchiveLibraryDir;
-}
-
 ### This gets the modalities that SNR is to be computed on
 ## Filename base usually contains the modality
 ## So compute SNR on the 3-D modalities; most commonly t1, t2, flair, and pd


### PR DESCRIPTION
Same as PR35 which I could not successfully rebase!

This used to be part of the ImagingUpload.pm in the moveUploadedFile() routine which is now removed (aces/Loris-MRI#111).