### PR TITLE
Add Performing Physician and Referring Physician Columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-.loris_mri/*
-.gitignore

--- a/2016-11-09-NewTarchiveColumns.sql
+++ b/2016-11-09-NewTarchiveColumns.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tarchive add ReferringPhysicianName varchar(255) default NULL;
+ALTER TABLE tarchive add PerformingPhysicianName varchar(255) default NULL;

--- a/DICOM/DCMSUM.pm
+++ b/DICOM/DCMSUM.pm
@@ -197,7 +197,7 @@ QUERY
        $self->{header}->{scanner_serial},        $self->{header}->{software},
        $self->{header}->{institution},           $self->{acquisition_count},
        $self->{nondcmcount},                     $self->{dcmcount},
-       $self->{user},                            $self->{dcmdir},
+       $creating_user,                           $self->{dcmdir},
        $self->{sumTypeVersion},                  $metacontent,
        $self->{header}->{referring_physician},   $self->{header}->{performing_physician}
       );


### PR DESCRIPTION
- Reading and archiving both the Performing Physician (Researcher) and the Referring Physician (PI) fields from the DICOM header into the tarchive table
- Includes an SQL patch that adds `ReferringPhysicianName` and `PerformingPhysicianName` to the database. If correct, need to create SQL patch for Loris to include these fields. 