### PR TITLE
Remove files with specific prefix from upload and __MACOSX directory: Redmine 11670

### DIFF
--- a/dicomTar.pl
+++ b/dicomTar.pl
@@ -101,7 +101,7 @@ my $system          = `uname`;
 
 
 # Remove .DS_Store from dcm_source directory if exist
-my $cmd = "cd " . $dcm_source . "; find -name '.DS_Store' | xargs rm";
+my $cmd = "cd " . $dcm_source . "; find -name '.DS_Store' | xargs rm -f";
 system($cmd);
 
 # create new summary object

--- a/dicomTar.pl
+++ b/dicomTar.pl
@@ -101,10 +101,8 @@ my $system          = `uname`;
 
 
 # Remove .DS_Store from dcm_source directory if exist
-if (-e $dcm_source . "/.DS_Store") {
-    my $cmd = "rm $dcm_source/.DS_Store";
-    system($cmd);
-}
+my $cmd = "cd " . $dcm_source . "; find -name '.DS_Store' | xargs rm";
+system($cmd);
 
 # create new summary object
 my $summary = DICOM::DCMSUM->new($dcm_source,$targetlocation);

--- a/dicomTar.pl
+++ b/dicomTar.pl
@@ -99,9 +99,11 @@ my $today           = sprintf("%4d-%02d-%02d",$year+1900,$mon+1,$mday);
 my $hostname        = inet_ntoa(scalar(gethostbyname(hostname() || 'localhost'))); #`hostname -f`; # fixme specify -f for fully qualified if you need it.
 my $system          = `uname`;
 
-
-# Remove .DS_Store from dcm_source directory if exist
-my $cmd = "cd " . $dcm_source . "; find -name '.DS_Store' | xargs rm -f";
+# Remove all files starting with . in the dcm_source directory
+my $cmd = "cd " . $dcm_source . "; find -name '.*' | xargs rm -f";
+system($cmd);
+# Remove __MACOSX directory
+my $cmd = "cd " . $dcm_source . "; find -name '__MACOSX' | xargs rm -rf";
 system($cmd);
 
 # create new summary object

--- a/dicomTar.pl
+++ b/dicomTar.pl
@@ -100,7 +100,7 @@ my $hostname        = inet_ntoa(scalar(gethostbyname(hostname() || 'localhost'))
 my $system          = `uname`;
 
 # Remove all files starting with . in the dcm_source directory
-my $cmd = "cd " . $dcm_source . "; find -name '.*' | xargs rm -f";
+my $cmd = "cd " . $dcm_source . "; find -type f -name '.*' | xargs rm -f";
 system($cmd);
 # Remove __MACOSX directory
 my $cmd = "cd " . $dcm_source . "; find -name '__MACOSX' | xargs rm -rf";


### PR DESCRIPTION
Based off of @gluneau's branch
**So this can be closed** if @gluneau can incorporate the additional changes in his pull request #46

This is to duplicate the removal of `__MACOSX` directory and all files starting with a `.` in the upload as in https://github.com/aces/Loris-MRI/pull/186.
Necessary to be done in both places as some projects use imaging uploaders while other use dicomTar .pl while bypassing imaging_upload_file.pl
